### PR TITLE
fix: Update PHP in DockerFile from 8.1 to 8.3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.3-fpm
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     }
   },
   "scripts": {
+    "dev": "vendor/bin/phel run src/main.phel",
     "build": "vendor/bin/phel build --no-cache",
     "format": "vendor/bin/phel format",
     "test": "vendor/bin/phel test"


### PR DESCRIPTION
## 📚 Description

I suggest updating the PHP version in the DockerFile from 8.1 to 8.3, as the current version won't even run on the project's composer (it requires PHP >= 8.2). I also suggest adding a "dev" command in the composer.json file so that you don't have to keep running "vendor/bin/phel run src/main.phel" every time.

