### PR TITLE
add Composer script for launching Phel REPL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "dev": "vendor/bin/phel run src/main.phel",
     "build": "vendor/bin/phel build --no-cache",
     "format": "vendor/bin/phel format",
-    "test": "vendor/bin/phel test"
+    "test": "vendor/bin/phel test",
+    "repl": "vendor/bin/phel repl"
   }
 }


### PR DESCRIPTION
## 📚 Description

Add a Composer script for launching the read-evaluate-print loop (REPL). It can be used as follows:

```shell
composer repl
```

## 🔖 Changes

- **composer.json** was updated to add a script that points to the command for launching the Phel REPL.
