### PR TITLE
fix: composer repl script times out after 300 seconds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
     "build": "vendor/bin/phel build --no-cache",
     "format": "vendor/bin/phel format",
     "test": "vendor/bin/phel test",
-    "repl": "vendor/bin/phel repl"
+    "repl": [
+      "Composer\\Config::disableProcessTimeout",
+      "vendor/bin/phel repl"
+    ]
   }
 }


### PR DESCRIPTION
## 📚 Description

After running `composer repl` and receiving the Phel REPL prompt, the Phel REPL will automatically exit back to the shell prompt after 300 seconds. This is done by Composer automatically after 300 seconds.

The solution is to disable the timeout: https://getcomposer.org/doc/06-config.md#process-timeout.

## 🔖 Changes

- In **composer.json**, specify that the timeout should be disabled for the `repl` script.
