### PR TITLE
Update PhelConfig method call to use named arguments

### DIFF
--- a/phel-config.php
+++ b/phel-config.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Phel\Config\PhelConfig;
 
-return PhelConfig::forProject('cli-skeleton.main')
+return PhelConfig::forProject(mainNamespace: 'cli-skeleton.main')
     ->withMainPhpPath('out/main.php')
     ->withIgnoreWhenBuilding(['local.phel'])
     ->withExportFromDirectories(['src/modules']);


### PR DESCRIPTION
## 📚 Description

From version 0.37+, the `PhelConfig::forProject()` method accepts a `layout` value as the first parameter.
