### PR TITLE
chore: bump phel-lang to 0.41.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=8.4",
-    "phel-lang/phel-lang": "dev-main",
+    "phel-lang/phel-lang": "^0.41",
     "symfony/console": "^7.3"
   },
   "require-dev": {


### PR DESCRIPTION
Bump `phel-lang/phel-lang` to 0.41.0. Tests pass.